### PR TITLE
Add vendor tagging via VENDORS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following variables are referenced by the scripts:
 | `MODEL_SUMMARY` | Model for summarisation (default `gpt-4.1`) |
 | `MODEL_CLASSIFIER` | Model for classification (default `gpt-4.1`) |
 | `DRIVE_FOLDER_ID` | Optional Google Drive folder ID for `ingest_drive.py` |
+| `VENDORS` | Comma-separated vendor names to tag pages (allowed `OpenAI`, `Google`, `Anthropic`, `Vanderbilt`) |
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- parse new `VENDORS` environment variable in `enrich.py`
- validate against a new `ALLOWED_VENDORS` set
- send vendor tags to Notion when updating rows
- document `VENDORS` in the README

## Testing
- `python -m py_compile enrich.py ingest_drive.py capture_rss.py`