### PR TITLE
Add summary toggle block to enrichment flow

### DIFF
--- a/enrich_rss.py
+++ b/enrich_rss.py
@@ -22,7 +22,9 @@ RSS_URL_PROP = os.getenv("RSS_URL_PROP", "Article URL")
 from enrich import (
     inbox_rows,
     add_fulltext_blocks,
+    add_summary_block,
     summarise_exec,
+    summarise,
     classify,
     notion_update,
 )
@@ -69,7 +71,13 @@ def main():
         try:
             print("   • Fetching article …")
             article_text = fetch_article_text(url)
+
+            print("   • Summarising with GPT-4.1 …")
+            detail = summarise(article_text)
+            add_summary_block(row["id"], detail)
+
             add_fulltext_blocks(row["id"], article_text)
+
             print("     ↳ extracted chars:", len(article_text))
 
             if not article_text.strip():


### PR DESCRIPTION
## Summary
- add `add_summary_block` helper for Notion toggle blocks
- insert detailed summary blocks before raw text blocks in `enrich.py`
- insert detailed summary blocks before raw text blocks in `enrich_rss.py`

## Testing
- `python -m py_compile enrich.py enrich_rss.py ingest_drive.py capture_rss.py`