### PR TITLE
Fix fallback for Responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Knowledge Pipeline
 
 Small utilities for capturing PDFs and RSS articles and storing them in a Notion database. The scripts can summarise and classify content using OpenAI models via the Responses API.
+They automatically fall back to Chat Completions if the installed OpenAI client
+doesn't yet support the Responses API (version < 1.3).
 
 ## Utilities
 


### PR DESCRIPTION
## Summary
- add compatibility wrapper when `OpenAI.responses` is missing
- use Chat Completions as a fallback in enrichment scripts
- document fallback in README

## Testing
- `python -m py_compile enrich.py postprocess.py ingest_drive.py capture_rss.py enrich_rss.py`