### PR TITLE
Fix incomplete PDF downloads

### DIFF
--- a/enrich.py
+++ b/enrich.py
@@ -138,8 +138,13 @@ def drive_id(url: str) -> str:
         raise ValueError(f"invalid Drive URL: {url}")
 
 def download_pdf(fid: str) -> bytes:
+    """Return the full binary contents of the Drive file."""
+    request = drive.files().get_media(fileId=fid)
     buf = io.BytesIO()
-    MediaIoBaseDownload(buf, drive.files().get_media(fileId=fid)).next_chunk()
+    downloader = MediaIoBaseDownload(buf, request)
+    done = False
+    while not done:
+        status, done = downloader.next_chunk()
     return buf.getvalue()
 
 @retry(wait=wait_exponential(2, 30), stop=stop_after_attempt(5),

--- a/infer_vendor.py
+++ b/infer_vendor.py
@@ -56,8 +56,12 @@ def drive_id(url: str) -> str:
 
 
 def download_pdf(drive, fid: str) -> bytes:
+    """Return the full binary contents of a Drive file."""
     buf = io.BytesIO()
-    MediaIoBaseDownload(buf, drive.files().get_media(fileId=fid)).next_chunk()
+    downloader = MediaIoBaseDownload(buf, drive.files().get_media(fileId=fid))
+    done = False
+    while not done:
+        status, done = downloader.next_chunk()
     return buf.getvalue()
 
 


### PR DESCRIPTION
## Summary
- loop through Drive chunks when downloading PDFs

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684a0a7761e0832c94ff3a4881c4bef0