### PR TITLE
Restrict vendor inference to predefined list

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ If a feed URL points to a Substack homepage, `capture_rss.py` automatically appe
 ```bash
 python infer_vendor.py
 ```
+Vendor inference is restricted to one of the following names: OpenAI, Anthropic,
+Google, Meta, X AI or DeepSeek. Anything else is left blank.
 
 6. Backfill missing Created Dates:
 


### PR DESCRIPTION
## Summary
- define allowed vendor names in `infer_vendor.py`
- instruct the model to choose only from known vendor names
- normalize the model output and return `Unknown` for unrecognised vendors
- document vendor restriction in README

## Testing
- `python -m py_compile infer_vendor.py enrich.py enrich_rss.py capture_rss.py ingest_drive.py postprocess.py infer_created_date.py`
- `pip install python-dotenv` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_68556c823c28832e9afa139670d42b33